### PR TITLE
PyPI Long Description Fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ def parse_requirements(filename):
 here = path.abspath(path.dirname(__file__))
 reqs = parse_requirements(path.join(here, "requirements.txt"))
 
+# Parses README
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name='linkrot',
 
@@ -27,7 +31,11 @@ setup(
     # https://packaging.python.org/en/latest/single_source_version.html
     version="2.0",
 
+    # Package Descriptions
     description='Extract metadata and URLs from PDF files',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+
     # The project's main homepage.
     url='https://github.com/marshalmiller/linkrot',
 

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,12 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
+
 def parse_requirements(filename):
     """ load requirements from a pip requirements file """
     lineiter = (line.strip() for line in open(filename))
     return [line for line in lineiter if line and not line.startswith("#")]
+
 
 here = path.abspath(path.dirname(__file__))
 reqs = parse_requirements(path.join(here, "requirements.txt"))


### PR DESCRIPTION
Resolves #15.

1. Parse `README.md` to obtain `long_description`.
2. Configure setup() with `long_description` and `long_description_content_type`.
3. Validated the change with personal **test.pypi.org** account - have since removed package.
4. Fixed small linting errors with regard to blank lines. 