### PR TITLE
Remove numpy import

### DIFF
--- a/linkrot/cli.py
+++ b/linkrot/cli.py
@@ -9,7 +9,6 @@ import argparse
 import json
 
 from urllib.parse import urlparse
-from numpy import unicode_
 
 import linkrot
 from linkrot.downloader import check_refs


### PR DESCRIPTION
Since python 2 support is removed, numpy is not needed