### PR TITLE
add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
 ]
 dependencies = [
     "pdfminer.six==20220524",
-    "chardet==5.0.0"
+    "chardet==5.0.0",
+    "lxml==4.9.1",
 ]
 
 [project.optional-dependencies]
@@ -44,6 +45,7 @@ dev = [
 	"mypy==0.981",
 	"pylint==2.15.3",
 	"pytest==7.1.3",
+	"build==0.8.0",
 ]
 test = [
 	"pytest==7.1.3",


### PR DESCRIPTION
Related to #123

**Note**: I have added `build` cause it is not built-in to python. New contributors who want to build the project, they need to install `build` through `dev` as documented:

```sh
pip install -e ".[dev]"
```