### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/safe-space.yml
+++ b/.github/workflows/safe-space.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 on: [issue_comment, pull_request_review]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/linkrot/security/code-scanning/6](https://github.com/rottingresearch/linkrot/security/code-scanning/6)

To fix this issue, the `permissions` key should be added to the workflow file `.github/workflows/safe-space.yml` at the root level. This ensures that all jobs in the workflow inherit restricted permissions. Since the workflow appears to check for toxicity in comments and pull request reviews, it likely does not need write access to the repository. Therefore, the permissions can be limited to `contents: read`, which allows read-only access to the repository contents. If a write permission is needed (e.g., for issues or pull requests), it should be added explicitly with the least privilege required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
