### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/linkrot/security/code-scanning/2](https://github.com/rottingresearch/linkrot/security/code-scanning/2)

To fix the issue, add a `permissions` block to the root of the workflow file. Since this workflow is for linting and does not require write permissions, the least privilege permissions should be applied: `contents: read`. This ensures the workflow has read-only access to the repository contents, which is sufficient for its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
