### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python_dist.yml
+++ b/.github/workflows/python_dist.yml
@@ -1,9 +1,10 @@
+permissions:
+  contents: read
 name: PyPi Dist
 
 on:
   release:
     types: [published]
-
 
 jobs:
   pypi-build-n-publish:


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/linkrot/security/code-scanning/3](https://github.com/rottingresearch/linkrot/security/code-scanning/3)

To address the issue, add the `permissions` key to the workflow at the root level. Since this workflow primarily interacts with the repository contents and publishes to PyPI, the `contents: read` permission is sufficient. There is no need for write access to repository contents or other permissions. This ensures that the `GITHUB_TOKEN` has the minimum required privileges.

The `permissions` block should be added immediately after the `name` key in the workflow file to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
