### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,9 @@ name: Pytest
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/linkrot/security/code-scanning/4](https://github.com/rottingresearch/linkrot/security/code-scanning/4)

To fix the issue, add the `permissions` key to the workflow file to explicitly set the required privileges for the `GITHUB_TOKEN`. Since this workflow focuses on building and testing code, it only needs read access to the repository contents. The recommended permissions block is:

```yaml
permissions:
  contents: read
```

This block should be added at the root level of the workflow file (before `jobs`) to apply to all jobs in the workflow. No additional changes to the existing functionality are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
