### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,7 @@
 name: Ruff
 on: [ push, pull_request ]
+permissions:
+  contents: read
 jobs:
   ruff:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/rottingresearch/linkrot/security/code-scanning/5](https://github.com/rottingresearch/linkrot/security/code-scanning/5)

To fix the problem, explicitly define the `permissions` key in the workflow. Since the `ruff` job runs a linter and does not require write access, the appropriate permission is `contents: read`. This will restrict the `GITHUB_TOKEN` to read-only access, ensuring that the workflow does not unintentionally have write permissions to the repository.

The permissions block should be added at the workflow root, so it applies to all jobs in the workflow. This avoids redundancy and ensures that permissions are clear and consistent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
