### PR TITLE
Add SCARF analytics support for PyPI installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Check out our sister project, [Rotting Research](https://github.com/marshalmille
 
 # Installation
 
+## Install with Usage Analytics (Optional but Recommended)
+
+```bash
+pip install linkrot --extra-index-url https://rotting-research.gateway.scarf.sh/simple/
+```
+
 ## PyPI (Recommended)
 Grab a copy of the code with pip:
  
@@ -375,6 +381,16 @@ The retraction checker uses multiple methods to detect retractions:
 - CrossRef API for retraction notices in metadata
 - Analysis of DOI landing pages for retraction indicators
 - Extensible design for adding more retraction databases
+
+# Usage Analytics
+This project uses SCARF to collect anonymous download statistics for package installations.
+
+SCARF acts as a proxy between the user and PyPI, allowing maintainers to better understand adoption and usage patterns.
+
+- No personal or identifiable information is collected  
+- Using SCARF is completely optional  
+
+If you would like to support the project, consider installing via the SCARF-enabled pip command.
 
 # Code of Conduct
 To view our code of conduct please visit our [Code of Conduct page](https://github.com/marshalmiller/rottingresearch/blob/main/code_of_conduct.md).


### PR DESCRIPTION
This PR integrates SCARF analytics to track PyPI installations for the linkrot package.

Changes:
- Added optional SCARF-enabled pip install command
- Retained default pip install to preserve simplicity
- Added a Usage Analytics section for transparency

SCARF acts as a proxy between pip and PyPI, recording anonymous download statistics before forwarding the request.

This helps maintainers better understand package adoption while ensuring no personal or identifiable information is collected.

This change follows open-source best practices by keeping SCARF optional while encouraging its use to support the project.

This complements SCARF analytics integration already introduced in the rottingresearch project, extending tracking to PyPI installations for linkrot. (see rottingresearch/rottingresearch#194).

Thanks,
Aakash Pal.